### PR TITLE
compile: Save group number to allow recursive group specs.

### DIFF
--- a/compilecode.c
+++ b/compilecode.c
@@ -112,11 +112,12 @@ const char *_compilecode(const char *re, ByteProg *prog)
             EMIT(term + 1, cnt);
             break;
         }
-        case '(':
+        case '(': {
             term = pc;
+            int sub = ++prog->sub;
 
             EMIT(pc++, Save);
-            EMIT(pc++, 2 * ++prog->sub);
+            EMIT(pc++, 2 * sub);
             prog->len++;
 
             prog->bytelen = pc;
@@ -124,10 +125,11 @@ const char *_compilecode(const char *re, ByteProg *prog)
             pc = prog->bytelen;
 
             EMIT(pc++, Save);
-            EMIT(pc++, 2 * prog->sub + 1);
+            EMIT(pc++, 2 * sub + 1);
             prog->len++;
 
             break;
+        }
         case '?':
             insert_code(code, term, 2, &pc);
             EMIT(term, Split);


### PR DESCRIPTION
prog->sub is possibly modified by the recursive call to _compilecode, so
we must save a local copy with our current value.
