### PR TITLE
Makefile: Add stuff to ease debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,26 @@
 # license that can be found in the LICENSE file.
 
 CC=gcc
-# Add -DDEBUG to CFLAGS when developing/testing
-CFLAGS=-ggdb -Wall -Os
-
 TARG=re
+# Set to 1 for debug compilation by default
+DEBUG ?= 0
+.DEFAULT_GOAL:=$(TARG)
+
+# "Production" compilation flags
+CFLAGS=-g3 -Wall -Os
+
+# Compilation flags for development
+# For -fsanitize=undefined, you may need to install libubsan
+DEBUG_CFLAGS=-DDEBUG -g3 -Wall -O0 -fsanitize=address,undefined -fno-omit-frame-pointer
+
+ifeq (1, $(DEBUG))
+	CFLAGS=$(DEBUG_CFLAGS)
+endif
+gdb: CFLAGS=$(DEBUG_CFLAGS)
+
+ASAN_SETUP=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer ASAN_OPTIONS=abort_on_error=1,symbolize=1
+
+
 OFILES=\
 	backtrack.o\
 	compile.o\
@@ -25,8 +41,8 @@ OFILES=\
 HFILES=\
 	re1.5.h\
 
-re: $(OFILES)
-	$(CC) -o re $(OFILES)
+$(TARG): $(OFILES)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OFILES)
 
 %.o: %.c $(HFILES)
 	$(CC) -c $(CFLAGS) $*.c
@@ -34,5 +50,14 @@ re: $(OFILES)
 y.tab.h y.tab.c: parse.y
 	bison -v -y parse.y
 
+gdb: $(TARG)
+	$(ASAN_SETUP) gdb ./$<
+
+# For now, LSAN (detect_leaks) is disabled because currently
+# allocated memory in the program not is freed.
+# Else its non-zero exit status causes the tests to fail.
+test: $(TARG)
+	$(ASAN_SETUP),detect_leaks=0 ./run-tests $(TFLAGS)
+
 clean:
-	rm -f *.o core re y.tab.[ch] y.output
+	rm -f *.o core $(TARG) y.tab.[ch] y.output


### PR DESCRIPTION
This is my proposal for a new Makefile.

The added ASAN definitions are for finding memory related bugs (e.g. out of bounds, use after free(), memory leaks, etc.) and various undefined behavior. See the commit message for more info on what has been added.

For -fsanitize=undefined, a recent enough gcc is needed (found on all recent Linux distributions).
