### PR TITLE
Cleanmarks: Add missing instructions.

### DIFF
--- a/cleanmarks.c
+++ b/cleanmarks.c
@@ -17,7 +17,7 @@ cleanmarks(ByteProg *prog)
         case RSplit:
         case Save:
         case Char:
-                pc++;
+            pc++;
         }
         pc++;
     }

--- a/cleanmarks.c
+++ b/cleanmarks.c
@@ -12,12 +12,27 @@ cleanmarks(ByteProg *prog)
     while (pc < end) {
         *pc &= 0x7f;
         switch (*pc) {
+        case Class:
+        case ClassNot:
+            pc += (unsigned char)pc[1] * 2;
+        case NamedClass:
         case Jmp:
         case Split:
         case RSplit:
         case Save:
         case Char:
             pc++;
+            break;
+#ifdef DEBUG
+        case Bol:
+        case Eol:
+        case Any:
+        case Match:
+            break;
+        default:
+            printf("Unknown instruction 0x%02x pc %ld\n", (unsigned char)*pc, pc - prog->insts);
+            re1_5_fatal("cleanmarks");
+#endif
         }
         pc++;
     }

--- a/run-tests
+++ b/run-tests
@@ -34,6 +34,11 @@ test_suite = [
     ("match", r"(\S+)\s+(\D+)", "ABC \thello abc456 abc"),
     ("match", r"(([0-9]*)([a-z]*)\d*)", "123hello456"),
 
+    # classes
+    ("match", r"[a]*", "a"),
+    ("search", r"([yab]*)(e*)([cd])", "xyac"),
+    ("search", r"([yab]*)(e*)([^y]?)$", "xyac"),
+
     # escaped metacharacters
     ("match", r"(\?:)", ":"),
     ("match", r"\(?:", "(:"),


### PR DESCRIPTION
With DEBUG (to prevent production code inflation) it includes the complete set of instructions, so missing ones (or other problems) can be detected. As discussed, an indentation problem is fixed in a separate commit. I also added some relevant tests.
The case fall-through of Class/ClassNot is to save slight code space.
