### PR TITLE
compilecode: Reject escaped end of string.

### DIFF
--- a/compilecode.c
+++ b/compilecode.c
@@ -21,6 +21,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
         switch (*re) {
         case '\\':
             re++;
+            if (!*re) return NULL; // Trailing backslash
             if ((*re | 0x20) == 'd' || (*re | 0x20) == 's' || (*re | 0x20) == 'w') {
                 term = PC;
                 EMIT(PC++, NamedClass);


### PR DESCRIPTION
Patterns with odd number of backslashes at their end are invalid.

What happens currently:

```
$ ./re -d '\'  test | cat -v
Precalculated size: 20
 0: rsplit 5 (3)
 2: any
 3: jmp 0 (-5)
 5: save 0
 7: char ^@
 9: char t
11: char e
13: char s
15: char t
17: save 1
19: match
Bytes: 20, insts: 11
```

Note that the end NUL byte is what is actually escaped, and then compilecode() misses the end of string (a kind of a buffer overflow) and continue to compile the subject string...

After this fix:

```
$ ./re -ed pike 'a\' test
Precalculated size: -1
fatal error: Error in regexp
```

In python3:

```
...
sre_constants.error: bogus escape (end of line)
```
