### PR TITLE
Qnongreedy

### DIFF
--- a/compilecode.c
+++ b/compilecode.c
@@ -69,10 +69,10 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             int capture = re[1] != '?' || re[2] != ':';
 
             if (capture) {
-                    sub = ++prog->sub;
-                    EMIT(PC++, Save);
-                    EMIT(PC++, 2 * sub);
-                    prog->len++;
+                sub = ++prog->sub;
+                EMIT(PC++, Save);
+                EMIT(PC++, 2 * sub);
+                prog->len++;
             } else {
                     re += 2;
             }
@@ -81,9 +81,9 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             if (re == NULL || *re != ')') return NULL; // error, or no matching paren
 
             if (capture) {
-                    EMIT(PC++, Save);
-                    EMIT(PC++, 2 * sub + 1);
-                    prog->len++;
+                EMIT(PC++, Save);
+                EMIT(PC++, 2 * sub + 1);
+                prog->len++;
             }
 
             break;

--- a/compilecode.c
+++ b/compilecode.c
@@ -91,7 +91,12 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
         case '?':
             if (PC == term) return NULL; // nothing to repeat
             INSERT_CODE(term, 2, PC);
-            EMIT(term, Split);
+            if (re[1] == '?') {
+                EMIT(term, RSplit);
+                re++;
+            } else {
+                EMIT(term, Split);
+            }
             EMIT(term + 1, REL(term, PC));
             prog->len++;
             break;

--- a/run-tests
+++ b/run-tests
@@ -46,6 +46,16 @@ test_suite = [
     # escaped metacharacters
     ("match", r"(\?:)", ":"),
     ("match", r"\(?:", "(:"),
+     
+    # non-greedy
+    ("match", r"a(b??)(b*)c", "abbc"),
+    ("match", r"a(b+?)(b*)c", "abbbc"),
+    ("match", r"a(b*?)(b*)c", "abbbbc"),
+    
+    # greedy
+    ("match", r"a(b?)(b*)c", "abbc"),
+    ("match", r"a(b+)(b*)c", "abbbc"),
+    ("match", r"a(b*)(b*)c", "abbbbc"),
 
     # errors
     ("search", r"?", ""),


### PR DESCRIPTION
ARM: +40
x86_64: +36

The greedy/non-greedy code repeats 3 times (for ?, \* and +).
If it is replaced by the macro EMIT_COND (see #14) it saves significant code space, while simplifying the source code.

Please indicate if a pull request for that is a good idea (already implemented).

In addition, see there (#14) for an **open question** of sending a pull request to revert the PC macro change (that is good for x86_64 but very bad for ARM), or to make it ifdef'ed something.
