### PR TITLE
compilecode: Signify |+, |* and |? as errors.

### DIFF
--- a/compilecode.c
+++ b/compilecode.c
@@ -137,6 +137,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             EMIT(start, Split);
             EMIT(start + 1, REL(start, PC));
             prog->len += 2;
+            term = PC;
             break;
         case '^':
             EMIT(PC++, Bol);

--- a/compilecode.c
+++ b/compilecode.c
@@ -142,10 +142,12 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
         case '^':
             EMIT(PC++, Bol);
             prog->len++;
+            term = PC;
             break;
         case '$':
             EMIT(PC++, Eol);
             prog->len++;
+            term = PC;
             break;
         }
     }

--- a/run-tests
+++ b/run-tests
@@ -46,12 +46,12 @@ test_suite = [
     # escaped metacharacters
     ("match", r"(\?:)", ":"),
     ("match", r"\(?:", "(:"),
-     
+
     # non-greedy
     ("match", r"a(b??)(b*)c", "abbc"),
     ("match", r"a(b+?)(b*)c", "abbbc"),
     ("match", r"a(b*?)(b*)c", "abbbbc"),
-    
+
     # greedy
     ("match", r"a(b?)(b*)c", "abbc"),
     ("match", r"a(b+)(b*)c", "abbbc"),

--- a/run-tests
+++ b/run-tests
@@ -68,6 +68,8 @@ test_suite = [
     ("search", "|+", ""),
     ("search", "|*", ""),
     ("search", "|?", ""),
+    ("search", "^*", ""),
+    ("search", "$*", ""),
 ]
 
 import re

--- a/run-tests
+++ b/run-tests
@@ -65,6 +65,9 @@ test_suite = [
     ("search", r"(", ""),
     ("search", r")", ""),
     ("search", "\\", ""),
+    ("search", "|+", ""),
+    ("search", "|*", ""),
+    ("search", "|?", ""),
 ]
 
 import re


### PR DESCRIPTION
Else incorrect regex code is generated, a thing that crashes the VM.
Also add them as test cases.

Fixing issue #25.
