### PR TITLE
compilecode: Disallow aQ* and aQ+ (Q is *, + or ?)

### DIFF
--- a/compilecode.c
+++ b/compilecode.c
@@ -99,6 +99,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             }
             EMIT(term + 1, REL(term, PC));
             prog->len++;
+            term = PC;
             break;
         case '*':
             if (PC == term) return NULL; // nothing to repeat
@@ -114,6 +115,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             }
             EMIT(term + 1, REL(term, PC));
             prog->len += 2;
+            term = PC;
             break;
         case '+':
             if (PC == term) return NULL; // nothing to repeat
@@ -126,6 +128,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
             EMIT(PC + 1, REL(PC, term));
             PC += 2;
             prog->len++;
+            term = PC;
             break;
         case '|':
             if (alt_label) {

--- a/run-tests
+++ b/run-tests
@@ -70,6 +70,9 @@ test_suite = [
     ("search", "|?", ""),
     ("search", "^*", ""),
     ("search", "$*", ""),
+    ("search", "a*+", ""),
+    ("search", "a*?", ""),
+    ("search", "a**", ""),
 ]
 
 import re


### PR DESCRIPTION
a_+, a?+, a_\* and a?\* cause an "infinite loop" in the recursive,
recursiveloop and backtrack VMs.

All of them raise "nothing to repeat" in Python3.

Also add tests.
