### PR TITLE
compilecode: Fix handling of '-' inside groups

### DIFF
--- a/compilecode.c
+++ b/compilecode.c
@@ -56,6 +56,14 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
                 if (!*re) return NULL;
                 EMIT(PC++, *re);
                 if (re[1] == '-') {
+                    if (re[2] == ']') {
+                        EMIT(PC++, *re);
+                        re += 1;
+                        cnt += 1;
+                        EMIT(PC++, *re);
+                        EMIT(PC++, *re);
+                        break;
+                    }
                     re += 2;
                 }
                 EMIT(PC++, *re);
@@ -65,7 +73,7 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
         }
         case '(': {
             term = PC;
-            int sub;
+            int sub = 0;
             int capture = re[1] != '?' || re[2] != ':';
 
             if (capture) {


### PR DESCRIPTION
Fix https://github.com/micropython/micropython/issues/3178

When '-' appears at the end of a class, treat it as literal '-'.

Copied from https://github.com/micropython/micropython/pull/3239